### PR TITLE
perf: remove the usage of charlists in favor of binaries

### DIFF
--- a/src/soap_client_util.erl
+++ b/src/soap_client_util.erl
@@ -260,7 +260,7 @@ parse_xml(Message, Model, Http_status, Http_headers,
                          #p_state{model = Model, version = Version,
                                   soap_ns = Ns, state = start,
                                   handler = Handler},
-                         fun xml_parser_cb_wrapped/2, []) of
+                         fun xml_parser_cb_wrapped/2, [{output_encoding, utf8}]) of
         {ok, #p_state{is_fault = true,
                       soap_headers = Decoded_headers,
                       soap_body = Decoded_fault,

--- a/src/soap_fault.erl
+++ b/src/soap_fault.erl
@@ -211,8 +211,6 @@ make_reasons(Fault_strings)
     when is_list(Fault_strings) andalso
          ((length(Fault_strings) == 0) orelse is_tuple(hd(Fault_strings))) ->
     [make_reason(Text) || Text <- Fault_strings];
-make_reasons(Fault_bin) when is_binary(Fault_bin) ->
-    make_reason(unicode:characters_to_list(Fault_bin));
 make_reasons(Fault_string) ->
     make_reason(#fault_reason{text = Fault_string}).
 

--- a/src/soap_fault.erl
+++ b/src/soap_fault.erl
@@ -300,7 +300,6 @@ fault_detail(Details, '1.2') ->
 xml_string(String) ->
     soap_req:xml_string(String).
 
-% TODO: String is binary()
 make_code(String, N_spaces) when is_list(String) ->
     case string:tokens(String, ":") of
         [Prefix, Local] ->

--- a/src/soap_server_handler.erl
+++ b/src/soap_server_handler.erl
@@ -524,7 +524,7 @@ handle(Parsed_body, Soap_req, Handler_s) ->
     Handler = soap_req:handler(Soap_req),
     case lists:keyfind(Record_type, #op.in_type, Operations) of
         false ->
-            {fault, soap_fault:fault(client, "Unknown operation", Soap_req),
+            {fault, soap_fault:fault(client, <<"Unknown operation">>, Soap_req),
              Soap_req, Handler_s};
         #op{operation = Operation} ->
             Handler:Operation(Parsed_body, Soap_req, Handler_s)

--- a/test/soap_SUITE.erl
+++ b/test/soap_SUITE.erl
@@ -413,7 +413,7 @@ client_11_ok(_Config) ->
   %% Normally one should include the record definition and use
   %% record syntax.
   %% TODO: the P0 prefixes should not be necessary.
-  {ok, 200, _,  _, {'P0:sendMessageResponse', "OK"}, [], _} =
+  {ok, 200, _,  _, {'P0:sendMessageResponse', <<"OK">>}, [], _} =
     sendService_client:'SendMessage'({'P0:sendMessage', "+31234567890", 
                             "Hello there", "Text"}, [], []).
 
@@ -434,7 +434,7 @@ client_11_fault(_Config) ->
 client_12_ok() ->
   [{userdata,[{doc,"use the generated client, receive OK answer"}]}].
 client_12_ok(_Config) ->
-  {ok, 200, Http_headers,  _, {'P0:sendMessageResponse', "OK"}, [], Raw} =
+  {ok, 200, Http_headers,  _, {'P0:sendMessageResponse', <<"OK">>}, [], Raw} =
     sendService_client:'SendMessage'({'P0:sendMessage', "+31234567890", 
                             "Hello there", "Text"}, [], []),
   "application/soap+xml" = proplists:get_value("Content-Type", Http_headers),
@@ -479,17 +479,19 @@ test_client(_Config) ->
 
 
 client_no_error(_Config) ->
-  {ok,200, Http_headers, [],#response_body{response = "ok"}, [], _} = 
+  {ok,200, Http_headers, [],#response_body{response = <<"ok">>}, [], _} = 
     test_service_client:do_test(#request_body{expected_response="ok"}, [], []),
   "text/xml" = proplists:get_value("Content-Type", Http_headers).
 
 client_unicode(_Config) ->
-  {ok,200, _, [],#response_body{response = "بِسْمِ ٱلرَّحْمـَبنِ ٱلرَّحِيمِ"}, [], _} = 
+  Expected = unicode:characters_to_binary("بِسْمِ ٱلرَّحْمـَبنِ ٱلرَّحِيمِ"),
+  {ok,200, _, [],#response_body{response = Expected}, [], _} = 
     test_service_client:do_test(#request_body{expected_response=
                                               "بِسْمِ ٱلرَّحْمـَبنِ ٱلرَّحِيمِ"}, [], []).
 
 client_unicode_binary(_Config) ->
-  {ok,200, _, [],#response_body{response = "بِسْمِ ٱلرَّحْمـَبنِ ٱلرَّحِيمِ"}, [], _} = 
+  Expected = unicode:characters_to_binary("بِسْمِ ٱلرَّحْمـَبنِ ٱلرَّحِيمِ"),
+  {ok,200, _, [],#response_body{response = Expected}, [], _} = 
     test_service_client:do_test(#request_body{
                                    expected_response=
                                        unicode:characters_to_binary("بِسْمِ ٱلرَّحْمـَبنِ ٱلرَّحِيمِ")},
@@ -500,7 +502,8 @@ inets_client_no_error(_Config) ->
   test_inets_client:do_test(#request_body{expected_response="sleep:0"}, [], []).
 
 inets_client_unicode(_Config) ->
-  {ok,200, _, [],#response_body{response = "بِسْمِ ٱلرَّحْمـَبنِ ٱلرَّحِيمِ"}, [], _} = 
+  Expected = unicode:characters_to_binary("بِسْمِ ٱلرَّحْمـَبنِ ٱلرَّحِيمِ"),
+  {ok,200, _, [],#response_body{response = Expected}, [], _} = 
     test_inets_client:do_test(#request_body{expected_response=
                                               "بِسْمِ ٱلرَّحْمـَبنِ ٱلرَّحِيمِ"}, [], []).
 
@@ -578,15 +581,15 @@ client_fault_encoding_header(_Config) ->
     test_service_client:do_test(#request_body{expected_response="fault_encoding_header"}, [], []).
 
 client_encoded_header(_Config) ->
-  {ok,200, _, [#header{header_field = "hello"}], #response_body{response = "ok"}, [], _} =
+  {ok,200, _, [#header{header_field = <<"hello">>}], #response_body{response = <<"ok">>}, [], _} =
     test_service_client:do_test(#request_body{expected_response="encoded_header"}, [], []).
 
 client_two_headers(_Config) ->
-  {ok,200, _, [_Hash,#header{header_field = "hello"}], #response_body{response = "ok"}, [], _} =
+  {ok,200, _, [_Hash,#header{header_field = <<"hello">>}], #response_body{response = <<"ok">>}, [], _} =
     test_service_client:do_test(#request_body{expected_response="two_headers"}, [], []).
 
 client_one_header_one_skipped(_Config) ->
-  {ok,200, _, [#header{header_field = "hello"}], #response_body{response = "ok"}, [], _} =
+  {ok,200, _, [#header{header_field = <<"hello">>}], #response_body{response = <<"ok">>}, [], _} =
     test_service_client:do_test(#request_body{expected_response="one_header_one_skipped"}, [], []).
 
 ibrowse_client_timeout(_Config) ->
@@ -595,7 +598,7 @@ ibrowse_client_timeout(_Config) ->
                             [{http_options, [{timeout, 1000}]}]).
 
 raw(_Config) ->
-  {ok,200, _, [], #response_body{response = "raw"}, [], _} =
+  {ok,200, _, [], #response_body{response = <<"raw">>}, [], _} =
     test_service_client:do_test(#request_body{expected_response="raw"}, [], []).
 
 raw_client(_Config) ->
@@ -603,7 +606,7 @@ raw_client(_Config) ->
               <<"ap/envelope/\"><s:Body><erlsom:request_body xmlns:erl">>,
               <<"som=\"test\"><expected_response>raw</expected_response>">>,
               "</erlsom:request_body></s:Body></s:Envelope>"],
-  {ok,200, _, [], #response_body{response = "raw"}, [], _} =
+  {ok,200, _, [], #response_body{response = <<"raw">>}, [], _} =
     test_service_client:do_test(Message, [], []).
 
 raw_client_error(_Config) ->
@@ -615,7 +618,7 @@ soap_req_no_headers(_Config) ->
     test_service_client:do_test(#request_body{expected_response="ok"}, [], []).
 
 soap_req_w_headers(_Config) ->
-  {ok,200, _, [],{response_body,"authenticated!"}, [], _} =
+  {ok,200, _, [],{response_body,<<"authenticated!">>}, [], _} =
     test_service_client:do_test(#request_body{expected_response="ok"}, 
                                 [], [{http_headers, [{"authorization", "user:pwd"}]}]).
 


### PR DESCRIPTION
We noticed a huge memory usage related to soap requests with large XML response, in our case the parsing of an XML file of ~20MB caused a memory consumption of more than 4GB.

With the help of the OTP observer we found out that the main problem was with [unicode:characters_to_list/1](https://www.erlang.org/doc/man/unicode.html#characters_to_list-1), so we tried to pass the [{output_encoding, utf8}](https://github.com/primait/erlang-soap/pull/8/commits/940ca136bf138a767c1ffd99df59bff313ac54d9) option to `erlsom:parse_sax` as advised on [willemdj/erlsom#57](https://github.com/willemdj/erlsom/issues/57#issuecomment-235951993) and it solved the issue.

We updated [soap_fault.erl](https://github.com/primait/erlang-soap/pull/8/commits/2196e80d951c199832e797a24cedae71b7894b91) in order to convert the binaries back into strings at least for error reporting since we don't expect to handle huge binaries there and possibly to keep the breaking changes surface to the minimum.

Please note that this is still a *BREAKING CHANGE*, so this is not a drop-in replacement for [bet365/soap](https://github.com/bet365/soap) anymore. You can see in https://github.com/primait/erlang-soap/pull/8/commits/b98f10364f5c69c6b4cb18fe8c7d97831f44ca42 how the response body now is [binary()](https://www.erlang.org/doc/man/erlang.html#type-binary) rather than a [string()](https://www.erlang.org/doc/man/erlang.html#type-string).

https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/CAB-6388